### PR TITLE
Add support for Mongodb Enterprise with Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ for connections from applications on this address. If not specified, the
 module will use the default for your OS distro.
 *Note:* This value should be passed as an array.
 
+##### `use_enterprise_repo`
+When `manage_package_repo` is set to true, this setting indicates if it will
+use the Community Edition (false, the default) or the Enterprise one (true).
+
 #####`version`
 The version of MonogDB to install/manage. This is a simple way of providing
 a specific version such as '2.2' or '2.4' for example. If not specified,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,10 +119,15 @@ class mongodb::params inherits mongodb::globals {
       if $manage_package {
         $user  = pick($::mongodb::globals::user, 'mongodb')
         $group = pick($::mongodb::globals::group, 'mongodb')
+        if $mongodb::globals::use_enterprise_repo == true {
+            $edition = 'enterprise'
+        } else {
+            $edition = 'org'
+        }
         if ($version == undef) {
-          $server_package_name = pick($::mongodb::globals::server_package_name, 'mongodb-org-server')
-          $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb-org-shell')
-          $mongos_package_name = pick($::mongodb::globals::mongos_package_name, 'mongodb-org-mongos')
+          $server_package_name = pick($::mongodb::globals::server_package_name, "mongodb-${edition}-server")
+          $client_package_name = pick($::mongodb::globals::client_package_name, "mongodb-${edition}-shell")
+          $mongos_package_name = pick($::mongodb::globals::mongos_package_name, "mongodb-${edition}-mongos")
           $package_ensure = true
           $package_ensure_client = true
           $package_ensure_mongos = true
@@ -131,9 +136,9 @@ class mongodb::params inherits mongodb::globals {
         } else {
           # check if the version is greater than 2.6
           if $version and (versioncmp($version, '2.6.0') >= 0) {
-            $server_package_name = pick($::mongodb::globals::server_package_name, 'mongodb-org-server')
-            $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb-org-shell')
-            $mongos_package_name = pick($::mongodb::globals::mongos_package_name, 'mongodb-org-mongos')
+            $server_package_name = pick($::mongodb::globals::server_package_name, "mongodb-${edition}-server")
+            $client_package_name = pick($::mongodb::globals::client_package_name, "mongodb-${edition}-shell")
+            $mongos_package_name = pick($::mongodb::globals::mongos_package_name, "mongodb-${edition}-mongos")
             $package_ensure = $version
             $package_ensure_client = $version
             $package_ensure_mongos = $version

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,20 +41,32 @@ class mongodb::repo (
         $location = $repo_location
       }
       elsif $version and (versioncmp($version, '3.0.0') >= 0) {
+        if $mongodb::globals::use_enterprise_repo == true {
+            $repo_domain = 'repo.mongodb.com'
+            $repo_path   = 'mongodb-enterprise'
+        } else {
+            $repo_domain = 'repo.mongodb.org'
+            $repo_path   = 'mongodb-org'
+        }
+
         $mongover = split($version, '[.]')
         $location = $::operatingsystem ? {
-          'Debian' => 'https://repo.mongodb.org/apt/debian',
-          'Ubuntu' => 'https://repo.mongodb.org/apt/ubuntu',
+          'Debian' => "https://${repo_domain}/apt/debian",
+          'Ubuntu' => "https://${repo_domain}/apt/ubuntu",
           default  => undef
         }
-        $release     = "${::lsbdistcodename}/mongodb-org/${mongover[0]}.${mongover[1]}"
+        $release     = "${::lsbdistcodename}/${repo_path}/${mongover[0]}.${mongover[1]}"
         $repos       = $::operatingsystem ? {
           'Debian' => 'main',
           'Ubuntu' => 'multiverse',
           default => undef
         }
-        $key         = '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10'
-        $key_server  = 'hkp://keyserver.ubuntu.com:80'
+        $key = "${mongover[0]}.${mongover[1]}" ? {
+          '3.4'   => '0C49F3730359A14518585931BC711F9BA15703C6',
+          '3.2'   => '42F3E95A2C4F08279C4960ADD68FA50FEA312927',
+          default => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10'
+        }
+        $key_server = 'hkp://keyserver.ubuntu.com:80'
       } else {
         $location = $::operatingsystem ? {
           'Debian' => 'http://downloads-distro.mongodb.org/repo/debian-sysvinit',


### PR DESCRIPTION
A non documented global variable 'use_enterprise_repo' existed to allow
the use of the Entreprise packages for RedHat.
This patch adds the option to Debian. It also tries to choose the right
APT key depending on the MongoDB version and adds the global variable to
the documentation.