### PR TITLE
Allow user-supplied configuration data

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ class mongodb::server {
 }
 ```
 
+##### `config_data`
+A hash to allow for additional configuration options
+to be set in user-provided template.
+
+
 ##### `rest`
 Set to true to enable a simple REST interface. Default: false
 
@@ -550,6 +555,9 @@ Config content if the default doesn't match one needs.
 
 ##### `config_template`
 Path to the config template if the default doesn't match one needs.
+
+##### `config_data`
+Hash containing key-value pairs to allow for additional configuration options to be set in user-provided template.
 
 ##### `configdb`
 Array of the config servers IP addresses the mongos should connect to.

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -5,6 +5,7 @@ class mongodb::mongos (
   $config_content   = undef,
   $config_template  = undef,
   $configdb         = $mongodb::params::mongos_configdb,
+  $config_data      = $mongodb::params::config_data,
   $service_manage   = $mongodb::params::mongos_service_manage,
   $service_provider = undef,
   $service_name     = $mongodb::params::mongos_service_name,

--- a/manifests/mongos/config.pp
+++ b/manifests/mongos/config.pp
@@ -5,6 +5,7 @@ class mongodb::mongos::config (
   $config_content  = $mongodb::mongos::config_content,
   $config_template = $mongodb::mongos::config_template,
   $configdb        = $mongodb::mongos::configdb,
+  $config_data     = $mongodb::mongos::config_data,
 ) {
 
   if ($ensure == 'present' or $ensure == true) {
@@ -13,8 +14,10 @@ class mongodb::mongos::config (
     if $config_content {
       $config_content_real = $config_content
     } elsif $config_template {
+      # Template has $config_data hash available
       $config_content_real = template($config_template)
     } else {
+      # Template has $config_data hash available
       $config_content_real = template('mongodb/mongodb-shard.conf.erb')
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,8 @@ class mongodb::params inherits mongodb::globals {
 
   $version = $::mongodb::globals::version
 
+  $config_data           = undef
+
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {
     'RedHat', 'Linux', 'Suse': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -69,6 +69,7 @@ class mongodb::server (
   $syslog           = undef,
   $config_content   = undef,
   $config_template  = undef,
+  $config_data      = undef,
   $ssl              = undef,
   $ssl_key          = undef,
   $ssl_ca           = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -6,6 +6,7 @@ class mongodb::server::config {
   $config           = $mongodb::server::config
   $config_content   = $mongodb::server::config_content
   $config_template  = $mongodb::server::config_template
+  $config_data      = $mongodb::server::config_data
   $dbpath           = $mongodb::server::dbpath
   $dbpath_fix       = $mongodb::server::dbpath_fix
   $pidfilepath      = $mongodb::server::pidfilepath
@@ -107,6 +108,8 @@ class mongodb::server::config {
     if $config_content {
       $cfg_content = $config_content
     } elsif $config_template {
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template($config_template)
     } elsif $version and (versioncmp($version, '2.6.0') >= 0) {
       # Template uses:
@@ -149,6 +152,9 @@ class mongodb::server::config {
       # - $system_logrotate
       # - $verbose
       # - $verbositylevel
+
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template('mongodb/mongodb.conf.2.6.erb')
     } else {
       # Fall back to oldest most basic config
@@ -205,6 +211,8 @@ class mongodb::server::config {
       # - $syslog
       # - $verbose
       # - $verbositylevel
+      # Template has available user-supplied data
+      # - $config_data
       $cfg_content = template('mongodb/mongodb.conf.erb')
     }
 

--- a/templates/mongodb-shard.conf.erb
+++ b/templates/mongodb-shard.conf.erb
@@ -19,3 +19,9 @@ logpath = <%= @logpath %>
 <% if @unixsocketprefix -%>
 unixSocketPrefix = <%= @unixsocketprefix %>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %> = <%= v %>
+<% end -%>
+<% end -%>

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -151,3 +151,9 @@ operationProfiling.slowOpThresholdMs: <%= @slowms %>
 <% if @set_parameter -%>
 setParameter: <%= @set_parameter %>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %>: <%= v %>
+<% end -%>
+<% end -%>

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -197,3 +197,9 @@ sslCAFile = <%= @ssl_ca %>
 sslWeakCertificateValidation = <%= @ssl_weak_cert %>
 <% end -%>
 <% end -%>
+
+<% if @config_data -%>
+<% @config_data.each do |k,v| -%>
+<%= k %> = <%= v %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Original PR from upstream: https://github.com/voxpupuli/puppet-mongodb/pull/389
This is mainly because we need `directoryForIndexes` for wiredtiger engine.